### PR TITLE
[AMS-13000] Fix role definitions on create and add test case

### DIFF
--- a/plugins/modules/users.py
+++ b/plugins/modules/users.py
@@ -222,7 +222,7 @@ class ManageUsers(ACL):
         """Create a user."""
         try:
             self.execute_cmd(
-                f"enable; manage acl create user {user} password {password} roles {roles}"
+                f"enable; manage acl create user {user} password {password} roles {' '.join(roles)}"
             )
             self.changed = True
         except (ACLError, ACLWarning) as err:

--- a/tests/unit/plugins/modules/test_users.py
+++ b/tests/unit/plugins/modules/test_users.py
@@ -445,7 +445,9 @@ def test_delete_user_error(mocker):
 
 
 def test_create_user_happy_exists(mocker):
+    commands = []
     def mock_execute_cmd(self, cmd):
+        commands.append(cmd)
         if cmd == "show users":
             return {
                 "groups": [
@@ -462,6 +464,7 @@ def test_create_user_happy_exists(mocker):
     mg.create_user("bar", "", ["1", "2", "3"])
 
     assert mg.message == "Created user bar with roles 1 2 3"
+    assert commands == ["show users", "enable; manage acl create user bar password  roles 1 2 3"]
     assert mg.failed == False
     assert mg.changed == True
 


### PR DESCRIPTION
When creating a user join the list of roles on space, also add test that verifies the command renders correctly.