### PR TITLE
[AMS-13102] Upgrade ansible to address vulnerabilities in deps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.9.16
+ansible==2.10.7
 black==22.3.0
 pytest==7.0.1
 pytest-cov==3.0.0


### PR DESCRIPTION
Bump the ansible version (installed in local venv and only used for development) to address dependabot flagged vulnerabilities.