### PR TITLE
[AMS-13443] Update to patched ansible version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.10.7
+ansible==2.9.23
 black==22.3.0
 pytest==7.0.1
 pytest-cov==3.0.0


### PR DESCRIPTION
Update to the patched version of ansible to address dependabot flagged vulnerability.

This change does not require bumping the version since this is just a development dependency.