### PR TITLE
AMS-13538: aerospike.acl support for create only state

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.10.8"
 
       - name: Setup virtualenv and run the unit tests
         working-directory: ansible/collections/ansible_collections/aerospike/acl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.10.8"
 
       - name: Package release
         id: package_release

--- a/plugins/modules/users.py
+++ b/plugins/modules/users.py
@@ -192,6 +192,7 @@ class ManageUsers(ACL):
             if user not in self.users:
                 return self.create_user(user, password, roles)
             if state == "create_only":
+                self.changed = False
                 self.failed = False
                 self.message = f"User {user} exists"
                 return True
@@ -285,7 +286,7 @@ def run_module():
         asadm_password=dict(type="str", required=False, default="admin"),
         user=dict(type="str", required=True),
         password=dict(type="str", required=False),
-        state=dict(type="str", required=False, choices=["present", "absent"], default="present"),
+        state=dict(type="str", required=False, choices=["present", "absent", "create_only"], default="present"),
         roles=dict(type="list", required=False, default=[]),
     )
 

--- a/plugins/modules/users.py
+++ b/plugins/modules/users.py
@@ -42,7 +42,7 @@ options:
         required: false
         type: list
         default: present
-        choices: [ present, absent ]
+        choices: [ present, absent, create_only ]
     user:
         description: The user to operate on.
         required: true
@@ -191,6 +191,10 @@ class ManageUsers(ACL):
                 return self.delete_user(user)
             if user not in self.users:
                 return self.create_user(user, password, roles)
+            if state == "create_only":
+                self.failed = False
+                self.message = f"User {user} exists"
+                return True
 
             grants = self.roles_to_grant(user, roles)
             revokes = self.roles_to_revoke(user, roles)

--- a/tests/unit/plugins/modules/test_users.py
+++ b/tests/unit/plugins/modules/test_users.py
@@ -304,6 +304,30 @@ def test_manage_user_create_error(mocker):
     assert mg.changed == False
 
 
+def test_manage_user_create_only_happy(mocker):
+
+    def mock_execute_cmd(self, cmd):
+        return {
+            "groups": [
+                {"records": [{"User": {"raw": "foo"}, "Roles": {"raw": ["a", "2", "c", "d"]}}]}
+            ]
+        }
+
+    mocker.patch(
+        "ansible_collections.aerospike.acl.plugins.module_utils.acl_common.ACL.execute_cmd",
+        mock_execute_cmd,
+    )
+
+    spy = mocker.spy(ManageUsers, "create_user")
+
+    mg = users.ManageUsers("", "", "", "", "")
+    mg.manage_user("foo", "biz", ["a", "b", "c"], "create_only")
+
+    assert spy.call_count == 0
+    assert mg.message == "User foo exists"
+    assert mg.failed == False
+    assert mg.changed == False
+
 def test_manage_user_update_happy(mocker):
     def mock_execute_cmd(self, cmd):
         return {


### PR DESCRIPTION
ability to support user that create once.
Test is checking that once user was created than its attributes are not changed by the plugin.

new state "create_only" is added.